### PR TITLE
export `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
   "module": "./esm/index.js",
   "type": "module",
   "exports": {
-    "import": "./esm/index.js",
-    "default": "./cjs/index.js"
+    "./package.json": "./package.json",
+    ".": {
+        "import": "./esm/index.js",
+        "default": "./cjs/index.js"
+    }
   }
 }


### PR DESCRIPTION
some build tools like `rollup-plugin-svelte` try to read the `package.json` of a project's packages