### PR TITLE
Reference types in export declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./types.d.ts",
       "import": "./esm/index.js",
       "default": "./cjs/index.js"
     },


### PR DESCRIPTION
Typescript cannot detect the typescript definitions of this package when you're running on typescript 4.7, with ES modules enabled. Typescript returns this error: `Could not find a declaration file for module ...`

It seems that typescript (as of 4.7, see [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing)) requires a `types` keyword in the esm `exports` definition.
This PR does that
