### PR TITLE
Reduce published package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .DS_Store
+.github
 .nyc_output
 .travis.yml
 node_modules/
@@ -6,4 +7,6 @@ coverage/
 rollup/
 test/
 php/test.php
+flatted.jpg
 package-lock.json
+SPECS.md


### PR DESCRIPTION
The published size of this package is 78.6kB, this PR reduces the package size by remove development and supporting files by adding them to `.npmignore`.

The following files have been added to `.npmignore`:

- `flatted.jpg`: reduces size 47.3kB (60.2%) 
- `.github` directory: reduces size by 1.24kB (1.6%)
- `SPEC.md`: reduces size by 3.6kB (4.6%)

This reduces the package size to 27.2kB