### PR TITLE
fix: drop php code from Node.js package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ node_modules/
 coverage/
 rollup/
 test/
-php/test.php
+php/
 flatted.jpg
 package-lock.json
 SPECS.md


### PR DESCRIPTION
There is very small to 0 profit in having a file with PHP code as a part of the final Node.js package. End users will probably rely on its Javascript/TypeScript part as part of the npm ecosystem. Besides dropping, it also will cut some bytes from network traffic. This may be important for a so widely used package

References #60 and commit 197796db