### PR TITLE
Fix #69 - Make `$value` an explicit class field

### DIFF
--- a/php/flatted.php
+++ b/php/flatted.php
@@ -19,6 +19,7 @@
  */
 
 class FlattedString {
+  public $value = '';
   public function __construct($value) {
     $this->value = $value;
   }


### PR DESCRIPTION
This MR simply set explicitly the `FlattedString $value` field as public so that deprecation notes are not shown.