### PR TITLE
add null to stringify type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
 export function parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
-export function stringify(value: any, replacer?: (string | number)[] | ((this: any, key: string, value: any) => any), space?: string | number | undefined): string;
+export function stringify(value: any, replacer?: (string | number)[] | ((this: any, key: string, value: any) => any) | null, space?: string | number | undefined): string;
 export function toJSON(value: any): any;
 export function fromJSON(value: any): any;


### PR DESCRIPTION
Comparing the jsdoc type in `index.js` to `types/index.d.ts` seems like `null` is missing for `stringify`, 2nd argument.

> ` * @param {((this: any, key: string, value: any) => any) | (string | number)[] | null | undefined} [replacer]`