### PR TITLE
fix: ignore non-JS languages when packaging for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,14 @@
 .DS_Store
 .github
 .nyc_output
-.travis.yml
 __pycache__/
 node_modules/
 coverage/
 rollup/
 test/
-php/test.php
+golang/
+php/
+python/
 flatted.jpg
 package-lock.json
 SPECS.md


### PR DESCRIPTION
[Version 3.3.4 published to npm](https://www.npmjs.com/package/flatted/v/3.3.4?activeTab=code) accidentally published the Go, PHP, and Python code that's also in the repository. Add these folders to `.npmignore` so that future releases to npm don't include it.